### PR TITLE
Enable email and social login in Reown AppKit

### DIFF
--- a/packages/nextjs/services/web3/wagmiConfig.tsx
+++ b/packages/nextjs/services/web3/wagmiConfig.tsx
@@ -6,10 +6,12 @@
  *
  * Key Features:
  * - Automatic wallet support (300+ wallets via WalletConnect Cloud)
+ * - Email & Social Login (Google, Apple, Discord, Farcaster) for easy onboarding
  * - No manual connector configuration needed
  * - Featured wallet prioritization (MetaMask, Trust, Coinbase)
  * - Multi-network support (Base Sepolia + Mainnet for ENS)
  * - Server-side rendering (SSR) compatible
+ * - SIWE (Sign-In with Ethereum) authentication
  *
  * Required Environment Variables:
  * - NEXT_PUBLIC_REOWN_PROJECT_ID: Get from https://cloud.reown.com
@@ -158,6 +160,18 @@ const featuredWalletIds = [
  * This must be called at module initialization (not in a React component).
  * Creates the global AppKit instance that powers <appkit-button /> and other components.
  *
+ * Email & Social Login:
+ * Users can now sign in without installing a wallet using:
+ * - Email: One-time password (OTP) sent to email
+ * - Google: Sign in with Google account
+ * - Apple: Sign in with Apple ID
+ * - Discord: Sign in with Discord account
+ * - Farcaster: Sign in with Farcaster account
+ *
+ * When users connect via email/social, Reown creates a non-custodial wallet for them
+ * that's secured by their authentication method. This significantly improves onboarding
+ * for users new to crypto.
+ *
  * Note: Burner wallet for testing/development requires custom implementation
  * with Reown AppKit. This will be handled separately.
  */
@@ -169,6 +183,9 @@ createAppKit({
   featuredWalletIds,
   features: {
     analytics: false, // Disable analytics for privacy
+    email: true, // Enable email login for easier onboarding
+    socials: ['google', 'apple', 'discord', 'farcaster'], // Enable social login options
+    emailShowWallets: true, // Show wallet options alongside email login
   },
   // Enable SIWE for authentication
   authentication: {


### PR DESCRIPTION
Implements issue #15: Enable Email & Social Login

Changes:
- Enable email login for easier user onboarding
- Add social login options: Google, Apple, Discord, Farcaster
- Set emailShowWallets: true to show wallet options alongside email
- Update documentation with email/social login details

Benefits:
- Users can connect without installing crypto wallets
- Reown creates non-custodial wallets secured by email/social auth
- Significantly lowers barrier to entry for new users
- Improves onboarding experience for Africa's smartphone users

Login methods now available:
- Email (OTP verification)
- Google Sign-In
- Apple ID
- Discord
- Farcaster
- Traditional wallet connections (MetaMask, Coinbase, etc.)

Closes #15